### PR TITLE
corrected representation of some identifiers to be consistent

### DIFF
--- a/example_MI_NOAA_DSMM.csv
+++ b/example_MI_NOAA_DSMM.csv
@@ -5,24 +5,30 @@ Title,MOM-ERGOM western Baltic Sea simulations with tagging of atmospheric nitro
 Publisher,World Data Center for Climate (WDCC) at DKRZ
 PublicationYear,2019
 ResourceType,Digital
-RelatedIdentifier,https://doi.org/10.6084/m9.figshare.1211954 (isSupplementedBy)
-RelatedIdentifier,https://doi.org/10.5334/dsj-2019-041 (isSourceOf)
-RelatedIdentifier,https://doi.org/10.5281/ZENODO.3666260 (isCitedBy)
+RelatedIdentifier,https://doi.org/10.6084/m9.figshare.1211954
+RelatedIdentifier -> relatedIdentifierType,DOI
+RelatedIdentifier -> relationType,isSupplementedBy
+RelatedIdentifier,https://doi.org/10.5334/dsj-2019-041
+RelatedIdentifier -> relatedIdentifierType,DOI
+RelatedIdentifier -> relationType,isSourceOf
+RelatedIdentifier,https://doi.org/10.5281/ZENODO.3666260
+RelatedIdentifier -> relatedIdentifierType,DOI
+RelatedIdentifier -> relationType,isCitedBy
 MaturityCheck -> maturityCheckSchemaVersion,v6.0
 MaturityCheck -> maturityCheckName,NOAA Data Stewardship Maturity Matrix (DSMM)
 MaturityCheck -> maturityCheckDescription,
 MaturityCheck -> maturityCheckResourceType,report/publication
 MaturityCheck -> maturityCheckResourceType -> resourceTypeGeneral,Text
 MaturityCheck -> maturityCheckIsMachineReadable,no
-MaturityCheck -> maturityCheckIdentifier,https://doi.org/10.2481/dsj.14-049
+MaturityCheck -> maturityCheckIdentifier,10.2481/dsj.14-049
 MaturityCheck -> maturityCheckIdentifier -> identifierScheme,DOI
 MaturityCheck -> maturityCheckIdentifier -> identifierScheme -> schemeURI,https://doi.org/
 MaturityCheck -> maturityCheckVersion,12/09/2014 Rev.1
 MaturityCheck -> maturityCheckPerformedBy -> performedByType,Creator
 MaturityCheck -> maturityCheckPerformedBy -> performedByName,"Heydebreck, Daniel"
-MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier,https://orcid.org/0000-0001-8574-9093
-MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier -> identifierScheme,DOI
-MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier -> identifierScheme -> schemeURI,https://doi.org/
+MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier,0000-0001-8574-9093
+MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier -> identifierScheme,ORCID
+MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier -> identifierScheme -> schemeURI,https://orcid.org/
 MaturityCheck -> maturityCheckReport,
 MaturityCheck -> maturityCheckReport -> reportDate,2020-07-20
 MaturityCheck -> maturityCheckReport -> reportMetric,

--- a/example_MI_NOAA_DSMM.csv
+++ b/example_MI_NOAA_DSMM.csv
@@ -10,54 +10,54 @@ RelatedIdentifier,https://doi.org/10.5334/dsj-2019-041 (isSourceOf)
 RelatedIdentifier,https://doi.org/10.5281/ZENODO.3666260 (isCitedBy)
 MaturityCheck -> maturityCheckSchemaVersion,v6.0
 MaturityCheck -> maturityCheckName,NOAA Data Stewardship Maturity Matrix (DSMM)
-MaturityCheck -> maturityCheckDescription, 
+MaturityCheck -> maturityCheckDescription,
 MaturityCheck -> maturityCheckResourceType,report/publication
 MaturityCheck -> maturityCheckResourceType -> resourceTypeGeneral,Text
-MaturityCheck -> maturityCheckIsMachineReadable, no
+MaturityCheck -> maturityCheckIsMachineReadable,no
 MaturityCheck -> maturityCheckIdentifier,https://doi.org/10.2481/dsj.14-049
-MaturityCheck -> maturityCheckIdentifier -> identifierScheme, DOI
+MaturityCheck -> maturityCheckIdentifier -> identifierScheme,DOI
 MaturityCheck -> maturityCheckIdentifier -> identifierScheme -> schemeURI,https://doi.org/
 MaturityCheck -> maturityCheckVersion,12/09/2014 Rev.1
 MaturityCheck -> maturityCheckPerformedBy -> performedByType,Creator
 MaturityCheck -> maturityCheckPerformedBy -> performedByName,"Heydebreck, Daniel"
 MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier,https://orcid.org/0000-0001-8574-9093
-MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier -> identifierScheme, DOI
+MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier -> identifierScheme,DOI
 MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier -> identifierScheme -> schemeURI,https://doi.org/
 MaturityCheck -> maturityCheckReport,
 MaturityCheck -> maturityCheckReport -> reportDate,2020-07-20
 MaturityCheck -> maturityCheckReport -> reportMetric,
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,preservability
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,4
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricName,preservability
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricResult,4
 MaturityCheck -> maturityCheckReport -> reportMetric -> unit,Level
 MaturityCheck -> maturityCheckReport -> reportMetric,
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,accessibility
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,3
-MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level
-MaturityCheck -> maturityCheckReport -> reportMetric,
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,usability
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,3
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricName,accessibility
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricResult,3
 MaturityCheck -> maturityCheckReport -> reportMetric -> unit,Level
 MaturityCheck -> maturityCheckReport -> reportMetric,
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,production sustainability
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,2
-MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricName,usability
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricResult,3
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit,Level
 MaturityCheck -> maturityCheckReport -> reportMetric,
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,data quality assurance
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,3
-MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricName,production sustainability
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricResult,2
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit,Level
 MaturityCheck -> maturityCheckReport -> reportMetric,
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,data quality control/monitoring
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,2
-MaturityCheck -> maturityCheckReport -> reportMetric -> unit, 1
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricName,data quality assurance
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricResult,3
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit,Level
 MaturityCheck -> maturityCheckReport -> reportMetric,
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,data quality assessment
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,2
-MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricName,data quality control/monitoring
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricResult,2
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit,1
 MaturityCheck -> maturityCheckReport -> reportMetric,
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,transparency/traceability
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,3
-MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricName,data quality assessment
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricResult,2
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit,Level
 MaturityCheck -> maturityCheckReport -> reportMetric,
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,data integrity
-MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,3
-MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricName,transparency/traceability
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricResult,3
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit,Level
+MaturityCheck -> maturityCheckReport -> reportMetric,
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricName,data integrity
+MaturityCheck -> maturityCheckReport -> reportMetric -> metricResult,3
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit,Level

--- a/example_MI_NOAA_DSMM.csv
+++ b/example_MI_NOAA_DSMM.csv
@@ -12,52 +12,52 @@ MaturityCheck -> maturityCheckSchemaVersion,v6.0
 MaturityCheck -> maturityCheckName,NOAA Data Stewardship Maturity Matrix (DSMM)
 MaturityCheck -> maturityCheckDescription, 
 MaturityCheck -> maturityCheckResourceType,report/publication
-MaturityCheck -> maturityCheckResourceType -> ResourceTypeGeneral,Text
+MaturityCheck -> maturityCheckResourceType -> resourceTypeGeneral,Text
 MaturityCheck -> maturityCheckIsMachineReadable, no
 MaturityCheck -> maturityCheckIdentifier,https://doi.org/10.2481/dsj.14-049
-MaturityCheck -> maturityCheckIdentifier -> IdentifierScheme, DOI
-MaturityCheck -> maturityCheckIdentifier -> IdentifierScheme -> schemeURI,https://doi.org/
+MaturityCheck -> maturityCheckIdentifier -> identifierScheme, DOI
+MaturityCheck -> maturityCheckIdentifier -> identifierScheme -> schemeURI,https://doi.org/
 MaturityCheck -> maturityCheckVersion,12/09/2014 Rev.1
-MaturityCheck -> maturityCheckPerformedBy -> PerformedByType,Creator
-MaturityCheck -> maturityCheckPerformedBy -> PerformedByName,"Heydebreck, Daniel"
-MaturityCheck -> maturityCheckPerformedBy -> PerformedByIdentifier,https://orcid.org/0000-0001-8574-9093
-MaturityCheck -> maturityCheckPerformedBy -> PerformedByIdentifier -> IdentifierScheme, DOI
-MaturityCheck -> maturityCheckPerformedBy -> PerformedByIdentifier -> IdentifierScheme -> schemeURI,https://doi.org/
+MaturityCheck -> maturityCheckPerformedBy -> performedByType,Creator
+MaturityCheck -> maturityCheckPerformedBy -> performedByName,"Heydebreck, Daniel"
+MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier,https://orcid.org/0000-0001-8574-9093
+MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier -> identifierScheme, DOI
+MaturityCheck -> maturityCheckPerformedBy -> performedByIdentifier -> identifierScheme -> schemeURI,https://doi.org/
 MaturityCheck -> maturityCheckReport,
-MaturityCheck -> maturityCheckReport -> ReportDate,2020-07-20
-MaturityCheck -> maturityCheckReport -> ReportMetric,
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricName,preservability
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricResult,4
-MaturityCheck -> maturityCheckReport -> ReportMetric -> unit,Level
-MaturityCheck -> maturityCheckReport -> ReportMetric,
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricName,accessibility
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricResult,3
-MaturityCheck -> maturityCheckReport -> ReportMetric -> unit, Level
-MaturityCheck -> maturityCheckReport -> ReportMetric,
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricName,usability
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricResult,3
-MaturityCheck -> maturityCheckReport -> ReportMetric -> unit,Level
-MaturityCheck -> maturityCheckReport -> ReportMetric,
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricName,production sustainability
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricResult,2
-MaturityCheck -> maturityCheckReport -> ReportMetric -> unit, Level
-MaturityCheck -> maturityCheckReport -> ReportMetric,
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricName,data quality assurance
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricResult,3
-MaturityCheck -> maturityCheckReport -> ReportMetric -> unit, Level
-MaturityCheck -> maturityCheckReport -> ReportMetric,
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricName,data quality control/monitoring
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricResult,2
-MaturityCheck -> maturityCheckReport -> ReportMetric -> unit, 1
-MaturityCheck -> maturityCheckReport -> ReportMetric,
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricName,data quality assessment
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricResult,2
-MaturityCheck -> maturityCheckReport -> ReportMetric -> unit, Level
-MaturityCheck -> maturityCheckReport -> ReportMetric,
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricName,transparency/traceability
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricResult,3
-MaturityCheck -> maturityCheckReport -> ReportMetric -> unit, Level
-MaturityCheck -> maturityCheckReport -> ReportMetric,
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricName,data integrity
-MaturityCheck -> maturityCheckReport -> ReportMetric -> MetricResult,3
-MaturityCheck -> maturityCheckReport -> ReportMetric -> unit, Level
+MaturityCheck -> maturityCheckReport -> reportDate,2020-07-20
+MaturityCheck -> maturityCheckReport -> reportMetric,
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,preservability
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,4
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit,Level
+MaturityCheck -> maturityCheckReport -> reportMetric,
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,accessibility
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,3
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level
+MaturityCheck -> maturityCheckReport -> reportMetric,
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,usability
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,3
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit,Level
+MaturityCheck -> maturityCheckReport -> reportMetric,
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,production sustainability
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,2
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level
+MaturityCheck -> maturityCheckReport -> reportMetric,
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,data quality assurance
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,3
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level
+MaturityCheck -> maturityCheckReport -> reportMetric,
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,data quality control/monitoring
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,2
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit, 1
+MaturityCheck -> maturityCheckReport -> reportMetric,
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,data quality assessment
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,2
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level
+MaturityCheck -> maturityCheckReport -> reportMetric,
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,transparency/traceability
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,3
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level
+MaturityCheck -> maturityCheckReport -> reportMetric,
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricName,data integrity
+MaturityCheck -> maturityCheckReport -> reportMetric -> MetricResult,3
+MaturityCheck -> maturityCheckReport -> reportMetric -> unit, Level


### PR DESCRIPTION
In the file version in this branch there is a mixture in the representation of identifiers. Some follow the proper DataCite representation. Others follow a simplified representation previously used. Now the representation of all identifiers is consistent and follows the DataCite representation.