### PR TITLE
Using relatedIdentifier and relation-type HasMetadata to link assessment reports

### DIFF
--- a/maturity_indicator_w_relatedIdentifiers/README.md
+++ b/maturity_indicator_w_relatedIdentifiers/README.md
@@ -1,0 +1,29 @@
+# Maturity Indicator (MI) Linking with Related Identifiers
+
+Currently (DataCite Metadata Schema v4.3), Maturity and assessment report information can be provided via `relatedIdentifier.`. Using relationTypes such as `HasMetadata` the Datcite provides mechanisms to identify and query assessment reports in DOI metadata unambiguously. 
+
+## Examples
+
+Also three example cases are provided -- each as `xml` and as `json` file. The files are:
+
+* `example_MI_*.xml`
+* `example_MI_*.json` (Schema.org JSON-LD)
+
+The examples are:
+
+| metric                                       | file suffix      | URL Scheme                                                         | Example Query |
+|----------------------------------------------|------------------|---------------------------------------------------------------------------------------|---|
+| FAIRsFAIR Draft Recommendation ... FAIR ...  | `_FAIRsFAIR`     | https://doi.org/10.5281/zenodo.3678716                                                | `query: related_identifiers.relatedMetadataScheme:"FAIRsFAIR"` |
+| WDCC Quality Maturity Matrix (QMM)           | `_WDCC_Maturity` | https://doi.org/10.2312/WDCC/TR_QMM_Checkl_Levels_4-5_Prots                           | `query: related_identifiers.relatedMetadataScheme:"WDCC_Maturity"` |
+| ARDC FAIR data assessment tool               | `ARDC_FAIR`      | https://ardc.edu.au/resources/working-with-data/fair-data/fair-self-assessment-tool/  | `query: related_identifiers.relatedMetadataScheme:"ARDC_FAIR"` |
+| NOAA Data Stewardship Maturity Matrix (DSMM) | `NOAA_DSMM`      | https://doi.org/10.2481/dsj.14-049                                                    | `query: related_identifiers.relatedMetadataScheme:"NOAA_DSMM"` |
+
+
+
+
+Note: the examples are currently not up to date.
+
+
+## Acknowledgements
+
+The Maturity Indicator draft was created within the AtMoDat project (**At**mospheric **Mo**del **Dat**a, https://www.atmodat.de). AtMoDat is funded by the German Federal Ministry for Education and Research within the framework of *Atmosphaeren-Modelldaten: Datenqualitaet, Kurationskriterien und DOI-Branding* (FKZ 16QK02A).

--- a/maturity_indicator_w_relatedIdentifiers/README.md
+++ b/maturity_indicator_w_relatedIdentifiers/README.md
@@ -4,10 +4,12 @@ Currently (DataCite Metadata Schema v4.3), Maturity and assessment report inform
 
 ## Examples
 
-Also three example cases are provided -- each as `xml` and as `json` file. The files are:
+Also three example cases are provided -- each as `xml`  file. The files are:
 
-* `example_MI_*.xml`
-* `example_MI_*.json` (Schema.org JSON-LD)
+* [RelatedIdentifier to ARDC;s FAIR report](/maturity_indicator_w_relatedIdentifiers/example_MI_ARDC_FAIR.xml)
+* [RelatedIdentifier to FAIR'sFAIR report](/maturity_indicator_w_relatedIdentifiers/example_MI_FAIRsFAIR.xml)
+* [RelatedIdentifier to NOAA's FAIR report](/maturity_indicator_w_relatedIdentifiers/example_MI_NOAA_DSMM.xml)
+* [RelatedIdentifier to WDDCC assessment report](/maturity_indicator_w_relatedIdentifiers/example_MI_WDCC_Maturity.xml)
 
 The examples are:
 

--- a/maturity_indicator_w_relatedIdentifiers/example_MI_ARDC_FAIR.xml
+++ b/maturity_indicator_w_relatedIdentifiers/example_MI_ARDC_FAIR.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4">
+    <identifier identifierType="DOI">10.26050/WDCC/MOMERGOMBSEMEP</identifier>
+    <!-- dropped `creator` for better readability --> 
+    <titles>
+        <title>MOM-ERGOM western Baltic Sea simulations with tagging of atmospheric nitrogen deposition by EMEP</title>
+    </titles>
+    <publisher>World Data Center for Climate (WDCC) at DKRZ</publisher>
+    <publicationYear>2019</publicationYear>
+    <resourceType resourceTypeGeneral="Dataset">Digital</resourceType>
+    <relatedIdentifiers>
+        <relatedIdentifier relatedIdentifierType="URL" relatedMetadataScheme="ARDC-FAIR" relationType="HasMetadata" schemeType="Text" schemeURI="https://ardc.edu.au/resources/working-with-data/fair-data/fair-self-assessment-tool">https://github.com/AtMoDat/maturity-indicator/blob/master/example_MI_ARDC_FAIR.xml</relatedIdentifier>
+    </relatedIdentifiers>
+</resource>

--- a/maturity_indicator_w_relatedIdentifiers/example_MI_FAIRsFAIR.xml
+++ b/maturity_indicator_w_relatedIdentifiers/example_MI_FAIRsFAIR.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4">
+    <identifier identifierType="DOI">10.26050/WDCC/MOMERGOMBSEMEP</identifier>
+    <!-- dropped `creator` for better readability --> 
+    <titles>
+        <title>MOM-ERGOM western Baltic Sea simulations with tagging of atmospheric nitrogen deposition by EMEP</title>
+    </titles>
+    <publisher>World Data Center for Climate (WDCC) at DKRZ</publisher>
+    <publicationYear>2019</publicationYear>
+    <resourceType resourceTypeGeneral="Dataset">Digital</resourceType>
+    <relatedIdentifiers>
+        <relatedIdentifier relatedIdentifierType="URL" relatedMetadataScheme="FAIRs-FAIR" relationType="HasMetadata" schemeType="Text" schemeURI="https://doi.org/10.5281/zenodo.3678716">https://github.com/AtMoDat/maturity-indicator/blob/master/example_MI_FAIRsFAIR.xml</relatedIdentifier>
+    </relatedIdentifiers>
+</resource>

--- a/maturity_indicator_w_relatedIdentifiers/example_MI_NOAA_DSMM.xml
+++ b/maturity_indicator_w_relatedIdentifiers/example_MI_NOAA_DSMM.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4">
+    <identifier identifierType="DOI">10.26050/WDCC/MOMERGOMBSEMEP</identifier>
+    <!-- dropped `creator` for better readability --> 
+    <titles>
+        <title>MOM-ERGOM western Baltic Sea simulations with tagging of atmospheric nitrogen deposition by EMEP</title>
+    </titles>
+    <publisher>World Data Center for Climate (WDCC) at DKRZ</publisher>
+    <publicationYear>2019</publicationYear>
+    <resourceType resourceTypeGeneral="Dataset">Digital</resourceType>
+    <relatedIdentifiers>
+        <relatedIdentifier relatedIdentifierType="DOI" relationType="isSupplementedBy">10.6084/m9.figshare.1211954</relatedIdentifier>
+        <relatedIdentifier relatedIdentifierType="DOI" relationType="isSourceOf">10.5334/dsj-2019-041</relatedIdentifier>
+        <relatedIdentifier relatedIdentifierType="DOI" relationType="isCitedBy">10.5281/ZENODO.3666260</relatedIdentifier>
+        <relatedIdentifier relatedIdentifierType="URL" relatedMetadataScheme="NOAA_DSMM" relationType="HasMetadata" schemeType="Text" schemeURI="https://doi.org/10.2481/dsj.14-049">https://github.com/AtMoDat/maturity-indicator/blob/master/example_MI_NOAA_DSMM.xml</relatedIdentifier>
+    </relatedIdentifiers>
+</resource>

--- a/maturity_indicator_w_relatedIdentifiers/example_MI_WDCC_Maturity.xml
+++ b/maturity_indicator_w_relatedIdentifiers/example_MI_WDCC_Maturity.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4">
+    <identifier identifierType="DOI">10.26050/WDCC/MOMERGOMBSEMEP</identifier>
+    <!-- dropped `creator` for better readability --> 
+    <titles>
+        <title>MOM-ERGOM western Baltic Sea simulations with tagging of atmospheric nitrogen deposition by EMEP</title>
+    </titles>
+    <publisher>World Data Center for Climate (WDCC) at DKRZ</publisher>
+    <publicationYear>2019</publicationYear>
+    <resourceType resourceTypeGeneral="Dataset">Digital</resourceType>
+    <relatedIdentifiers>
+        <relatedIdentifier relatedIdentifierType="URL" relatedMetadataScheme="WDCC_Maturity" relationType="HasMetadata" schemeType="Text" schemeURI="https://doi.org/10.2312/WDCC/TR_QMM_Checkl_Levels_4-5_Prots">https://github.com/AtMoDat/maturity-indicator/blob/master/example_MI_FWDCC_Maturity.xml</relatedIdentifier>
+    </relatedIdentifiers>
+</resource>


### PR DESCRIPTION
relation-type HasMetadata can be used to disambiguate related identifiers. 

This PR show some examples based on AtMoDat examples.

